### PR TITLE
Rename grafana NodePort service

### DIFF
--- a/prometheus/manifests/grafana/grafana-svc.yaml.example
+++ b/prometheus/manifests/grafana/grafana-svc.yaml.example
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana
+  name: grafana-nodeport
 spec:
   type: NodePort
   ports:


### PR DESCRIPTION
Done to avoid collision with the service in grafana-deployment.yaml