### PR TITLE
k8s 1.17 deprecates rbac v1/beta1 api

### DIFF
--- a/kafka/01-rbac.yaml
+++ b/kafka/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kafka
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kafka
@@ -21,7 +21,7 @@ rules:
 
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kafka
 roleRef:

--- a/prometheus/manifests/grafana/grafana-deployment.yaml
+++ b/prometheus/manifests/grafana/grafana-deployment.yaml
@@ -116,7 +116,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: grafana/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: grafana
@@ -129,7 +129,7 @@ rules:
   resourceNames:  [grafana]
 ---
 # Source: grafana/templates/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: grafana

--- a/prometheus/manifests/prometheus/000-prometheus-rbac.yaml
+++ b/prometheus/manifests/prometheus/000-prometheus-rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus
@@ -11,7 +11,7 @@ subjects:
   name: prometheus
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus


### PR DESCRIPTION
See k8s release notes - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.17.md#downloads-for-v1170

The v1 api has existed since v1.13 https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#clusterrole-v1-rbac-authorization-k8s-io