### PR TITLE
Update job generator script to allow storageos node id to be passed

### DIFF
--- a/FIO/local-volumes/README.md
+++ b/FIO/local-volumes/README.md
@@ -17,14 +17,37 @@ kubectl get node --show-labels
 > The Node selected must have enough capacity to host all the volumes
 > created for the test.
 
+Get the StorageOS node ID for the same node - e846e605-d1c8-4d44-82bf-f6ba8080ece3 in the output below
+
+```bash
+storageos describe node $NODE
+ID                                      e846e605-d1c8-4d44-82bf-f6ba8080ece3
+Name                                    kind-worker2
+Health                                  online
+Addresses:
+  Data Transfer address                 10.61.0.13:5703
+  Gossip address                        10.61.0.13:5711
+  Supervisor address                    10.61.0.13:5704
+  Clustering address                    10.61.0.13:5710
+Labels                                  beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=...
+Created at                              2020-03-30T15:51:27Z (2 hours ago)
+Updated at                              2020-03-30T15:56:37Z (2 hours ago)
+Version                                 MQ
+Available capacity                      490 MiB/9.8 GiB (8.8 GiB in use)
+
+Local volume deployments:
+  DEPLOYMENT ID                         VOLUME                                                                            NAMESPACE  HEALTH  TYPE    SIZE
+  4a109049-f26d-4e7d-bdd4-22f4657aa1cb  pvc-ae11774d-a4b2-4a21-83e9-695c17e8ca6a                                          default    online  master  2.0 GiB
+```
+
 2. Generate tests (4, 8, 16 and 32 volumes)
 
 
 ```bash
-~$ ./job-generator-per-volumecount.sh 4  $NODE_NAME1
-~$ ./job-generator-per-volumecount.sh 8  $NODE_NAME2
-~$ ./job-generator-per-volumecount.sh 16 $NODE_NAME3
-~$ ./job-generator-per-volumecount.sh 32 $NODE_NAME4
+~$ ./job-generator-per-volumecount.sh 4  $NODE_NAME1 $STOS_NODE_ID
+~$ ./job-generator-per-volumecount.sh 8  $NODE_NAME2 $STOS_NODE_ID
+~$ ./job-generator-per-volumecount.sh 16 $NODE_NAME3 $STOS_NODE_ID
+~$ ./job-generator-per-volumecount.sh 32 $NODE_NAME4 $STOS_NODE_ID
 ```
 
 The Job Generator creates a Job in `./jobs/` for each execution and its

--- a/FIO/local-volumes/README.md
+++ b/FIO/local-volumes/README.md
@@ -79,10 +79,10 @@ injected into the Job.
 # Use StorageOS CLI to verify where the volumes are collocated
 
 # As a binary
-~$ storageos volume ls 
+~$ storageos get volumes 
 
 # As a container
-~$ kubectl -n storageos exec cli -- storageos volume ls
+~$ kubectl -n storageos exec cli -- storageos get volumes
 
 
 # Verify that the Pod is running in the same Node

--- a/FIO/local-volumes/job-generator-per-volumecount.sh
+++ b/FIO/local-volumes/job-generator-per-volumecount.sh
@@ -6,11 +6,17 @@ if [ -z "$1" ]; then
 fi
 
 if [ -z "$2" ]; then
-    echo "Node not defined (volume hint, nodeSelector)"
+    echo "Node not defined (pod nodeSelector)"
 fi
+
+if [ -z "$3" ]; then
+    echo "StorageOS node not defined (volume hint, nodeSelector)"
+fi
+
 
 num_vols="$1"
 node="$2"
+stos_node="$3"
 pvc_prefix="$RANDOM"
 profile="profile-${num_vols}vol.fio"
 manifest="./jobs/fio-${num_vols}vol.yaml"
@@ -26,7 +32,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-${pvc_prefix}-$v
   labels:
-    storageos.com/hint.master: "$node"
+    storageos.com/hint.master: "$stos_node"
   annotations:
     volume.beta.kubernetes.io/storage-class: fast
 spec:
@@ -54,7 +60,7 @@ spec:
         kubernetes.io/hostname: "$node"
       containers:
       - name: fio
-        image: senax/docker-fio:latest
+        image: storageos/docker-fio:1.0.0
         command:
           - "fio"
           - "/tmp/$profile"

--- a/FIO/remote-local-volumes/README.md
+++ b/FIO/remote-local-volumes/README.md
@@ -35,10 +35,10 @@ injected into the Job.
 # Use StorageOS CLI to verify where the volumes are collocated
 
 # As a binary
-~$ storageos volume ls 
+~$ storageos get volumes 
 
 # As a container
-~$ kubectl -n storageos exec cli -- storageos volume ls
+~$ kubectl -n storageos exec cli -- storageos get volumes
 
 
 # Verify that the Pod is running


### PR DESCRIPTION
hint.master now requires a StorageOS node ID and I changed the container to use our FIO container. 