### PR TITLE
Fixing some FIO variable names

### DIFF
--- a/FIO/remote-volumes/dbench-job-generator-remote-volume-replica.sh
+++ b/FIO/remote-volumes/dbench-job-generator-remote-volume-replica.sh
@@ -68,8 +68,7 @@ node_details=$(kubectl -n ${STOS_NS} exec cli -- storageos describe nodes -ojson
 local_node_name=$(echo $node_details | jq -r '.[0]')
 local_node_id=$(echo $node_details | jq -r '.[1]')
 
-remote_node_name=$(echo $node_details | jq -r '.[2]')
-remote_node_name=$(echo $node_details | jq -r '.[3]')
+remote_node_id=$(echo $node_details | jq -r '.[3]')
 
 pvc_prefix="$RANDOM"
 
@@ -88,7 +87,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-${pvc_prefix}
   labels:
-    storageos.com/hint.master: "${remote_node_name}"
+    storageos.com/hint.master: "${remote_node_id}"
     storageos.com/replicas: "1"
 spec:
   storageClassName: fast

--- a/FIO/remote-volumes/dbench-job-generator-remote-volume.sh
+++ b/FIO/remote-volumes/dbench-job-generator-remote-volume.sh
@@ -68,8 +68,7 @@ node_details=$(kubectl -n ${STOS_NS} exec cli -- storageos describe nodes -ojson
 local_node_name=$(echo $node_details | jq -r '.[0]')
 local_node_id=$(echo $node_details | jq -r '.[1]')
 
-remote_node_name=$(echo $node_details | jq -r '.[2]')
-remote_node_name=$(echo $node_details | jq -r '.[3]')
+remote_node_id=$(echo $node_details | jq -r '.[3]')
 
 pvc_prefix="$RANDOM"
 # Create a temporary dir where the remote-volume-without-replica-fio.yaml will get created in
@@ -87,7 +86,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-${pvc_prefix}
   labels:
-    storageos.com/hint.master: "${remote_node_name}"
+    storageos.com/hint.master: "${remote_node_id}"
 spec:
   storageClassName: fast
   accessModes:


### PR DESCRIPTION
Some of the FIO variable names were misleading since they were referring to node_id not node_name like the other scripts: https://github.com/storageos/use-cases/blob/master/FIO/local-volumes/dbench-job-generator-local-volume.sh#L89